### PR TITLE
Create TRC20Capped.sol

### DIFF
--- a/contracts/tokens/TRC20/TRC20Capped.sol
+++ b/contracts/tokens/TRC20/TRC20Capped.sol
@@ -1,0 +1,28 @@
+pragma solidity ^0.4.23;
+
+import "./TRC20Mintable.sol";
+
+/**
+ * @title Capped token
+ * @dev Mintable token with a token cap.
+ */
+contract TRC20Capped is TRC20Mintable {
+    uint256 private _cap;
+
+    constructor (uint256 cap) public {
+        require(cap > 0);
+        _cap = cap;
+    }
+
+    /**
+     * @return the cap for the token minting.
+     */
+    function cap() public view returns (uint256) {
+        return _cap;
+    }
+
+    function _mint(address account, uint256 value) internal {
+        require(totalSupply().add(value) <= _cap);
+        super._mint(account, value);
+    }
+}


### PR DESCRIPTION
TRC20Capped is a type of TRC20Mintable that enforces a maximum cap on tokens; this is really useful if you want to ensure network participants that there will always be a maximum number of tokens, and is useful for making sure that multiple different minting methods don't accidentally create more tokens than you expected.

Ref: https://openzeppelin.org/api/docs/learn-about-tokens.html